### PR TITLE
Relax LNURLP status checks

### DIFF
--- a/src/esp32/ESP32Transport.cpp
+++ b/src/esp32/ESP32Transport.cpp
@@ -43,8 +43,8 @@ void esp32::ESP32Transport::getInvoiceFromLNAddr(NostrString addr, unsigned long
             return;
         }
         NostrString status = doc["status"];
-        if (!NostrString_equals(status, "OK")) {
-            Utils::log("LNURLP status not OK");
+        if (status != "" && !NostrString_equals(status, "OK")) {
+            Utils::log("LNURLP status is set but not OK");
             cb("");
             return;
         }
@@ -75,8 +75,8 @@ void esp32::ESP32Transport::getInvoiceFromLNAddr(NostrString addr, unsigned long
                 return;
             }
             NostrString callbackStatus = doc["status"];
-            if (!NostrString_equals(callbackStatus, "OK")) {
-                Utils::log("LNURLP callback status not OK");
+            if (callbackStatus != "" && !NostrString_equals(callbackStatus, "OK")) {
+                Utils::log("LNURLP callback status is set but not OK");
                 cb("");
                 return;
             }

--- a/src/esp32/ESP32Transport.cpp
+++ b/src/esp32/ESP32Transport.cpp
@@ -43,8 +43,8 @@ void esp32::ESP32Transport::getInvoiceFromLNAddr(NostrString addr, unsigned long
             return;
         }
         NostrString status = doc["status"];
-        if (status != "" && !NostrString_equals(status, "OK")) {
-            Utils::log("LNURLP status is set but not OK");
+        if (!NostrString_equals(status,"null") && !NostrString_equals(status, "OK")) {
+            Utils::log("LNURLP status is set but not OK, status is: '" + status + "'");
             cb("");
             return;
         }
@@ -75,8 +75,8 @@ void esp32::ESP32Transport::getInvoiceFromLNAddr(NostrString addr, unsigned long
                 return;
             }
             NostrString callbackStatus = doc["status"];
-            if (callbackStatus != "" && !NostrString_equals(callbackStatus, "OK")) {
-                Utils::log("LNURLP callback status is set but not OK");
+            if (!NostrString_equals(callbackStatus,"null") && !NostrString_equals(callbackStatus, "OK")) {
+                Utils::log("LNURLP callback status is set but not OK, status is: '" + callbackStatus + "'");
                 cb("");
                 return;
             }


### PR DESCRIPTION
Some LNURLP implementations (such as the LNBits 0.12.x on demo.lnpiggy.com) don't send a "status" field in their initial response, nor in their invoice reponse.

This was causing getInvoiceFromLNAddr() to fail,
even though it works fine with other tested clients.

Instead of failing if the status is not present or if it's not OK, this commit only fails if the status is not OK,
but continues if there is no explicit status field set.