### PR TITLE
Add support for fragmented websocket messages

### DIFF
--- a/src/esp32/ESP32Transport.cpp
+++ b/src/esp32/ESP32Transport.cpp
@@ -187,6 +187,25 @@ esp32::ESP32Connection::ESP32Connection(ESP32Transport *transport, NostrString u
                 }
             }
             break;
+        case WStype_FRAGMENT_TEXT_START:
+            Utils::log("Fragmented message start.");
+            this->fragmentedMessage = NostrString_fromChars((char *)payload);
+            break;
+        case WStype_FRAGMENT:
+            Utils::log("Fragmented message continued.");
+            this->fragmentedMessage += NostrString_fromChars((char *)payload);
+            break;
+        case WStype_FRAGMENT_FIN:
+            Utils::log("Fragmented message finalized.");
+            this->fragmentedMessage += NostrString_fromChars((char *)payload);
+            for (auto &listener : messageListeners) {
+                try {
+                    listener(this->fragmentedMessage);
+                } catch (std::exception &e) {
+                    Utils::log(e.what());
+                }
+            }
+            break;
         default:
             break;
         }

--- a/src/esp32/ESP32Transport.cpp
+++ b/src/esp32/ESP32Transport.cpp
@@ -198,6 +198,7 @@ esp32::ESP32Connection::ESP32Connection(ESP32Transport *transport, NostrString u
         case WStype_FRAGMENT_FIN:
             Utils::log("Fragmented message finalized.");
             this->fragmentedMessage += NostrString_fromChars((char *)payload);
+            Utils::log("Assembled fragmented message: " + this->fragmentedMessage);
             for (auto &listener : messageListeners) {
                 try {
                     listener(this->fragmentedMessage);

--- a/src/esp32/ESP32Transport.h
+++ b/src/esp32/ESP32Transport.h
@@ -45,6 +45,7 @@ class ESP32Connection : public Connection {
     WebSocketsClient ws;
     std::vector<std::function<void(NostrString)>> messageListeners;
     std::vector<std::function<void(ConnectionStatus status)>> connectionListeners;
+    NostrString fragmentedMessage;
 };
 class ESP32Transport : public Transport {
   public:


### PR DESCRIPTION
Some NWC server-side implementations, such as the one one by Alby, tend to fragment their websocket messages, especially for bigger ones such as list_transactions replies.
    
This work adds support for assembling these fragments on the receiving end, and handing them off like regular text, abstracting away this complexity for the user.

Since the code prints regular received messages of type WStype_TEXT, it seems logical to also print assembled fragmented messages in a similar vain.