### PR TITLE
Nip04::decrypt - Allocate memory on the heap instead of the stack

### DIFF
--- a/src/Nip04.cpp
+++ b/src/Nip04.cpp
@@ -81,7 +81,7 @@ NostrString Nip04::decryptData(byte key[32], byte iv[16], NostrString messageHex
     AES_ctx ctx;
     AES_init_ctx_iv(&ctx, key, iv);
     AES_CBC_decrypt_buffer(&ctx, messageBin, byteSize);
-    String result = NostrString_substring(NostrString((char *)messageBin),0, byteSize);
+    NostrString result = NostrString_substring(NostrString((char *)messageBin),0, byteSize);
     free(messageBin);
     return result;
 }

--- a/src/Nip04.cpp
+++ b/src/Nip04.cpp
@@ -10,8 +10,7 @@ NostrString Nip04::decrypt(NostrString &privateKeyHex, NostrString &senderPubKey
 
     NostrString encryptedMessageHex = Utils::base64ToHex(encryptedMessage);
     int encryptedMessageSize = NostrString_length(encryptedMessageHex) / 2;
-    byte encryptedMessageBin[encryptedMessageSize];
-    Utils::fromHex(encryptedMessageHex, encryptedMessageBin, encryptedMessageSize);
+    if (!encryptedMessageSize) return NostrString(); // nothing to do (can happen if base64ToHex returns "" because out of memory)
 
     NostrString iv = NostrString_substring(content, ivParamIndex + 4);
     NostrString ivHex = Utils::base64ToHex(iv);
@@ -76,12 +75,13 @@ void Nip04::stringToByteArray(const char *input, int padding_diff, byte *output)
 
 NostrString Nip04::decryptData(byte key[32], byte iv[16], NostrString messageHex) {
     int byteSize = NostrString_length(messageHex) / 2;
-    byte messageBin[byteSize];
+    byte* messageBin = (byte*)malloc(byteSize);
+    if (!messageBin) return NostrString();
     Utils::fromHex(messageHex, messageBin, byteSize);
-
     AES_ctx ctx;
     AES_init_ctx_iv(&ctx, key, iv);
-    AES_CBC_decrypt_buffer(&ctx, messageBin, sizeof(messageBin));
-
-    return NostrString_substring(NostrString((char *)messageBin),0, byteSize);
+    AES_CBC_decrypt_buffer(&ctx, messageBin, byteSize);
+    String result = NostrString_substring(NostrString((char *)messageBin),0, byteSize);
+    free(messageBin);
+    return result;
 }


### PR DESCRIPTION
When receiving big responses, such as for list_transactions, the memory constraints of the ESP32 really become apparent, especially when using the pre-built esp-idf from the Arduino IDE's board manager, with its fixed configuration.

The stack memory size is particularly constaining. It seems to have around ~4KB free when the code ends up in the loop() function, so there's really no room to allocate big arrays there.

A typical transaction from a list_transactions reply is around 4KB on its own because NWC is a pretty verbose protocol (JSON encapsulation, encryption, base64 encoding, hex encoding) and it was causing a crash due to all the stack memory being used up.

This modification allocates the memory on the heap using malloc(), which fixes the issue.
It also removes the unused encryptedMessageBin array - an easy win to reduce stack memory usage :-D

The heap memory itself is also pretty limited, and there are probably other places that would need to be rewritten to improve this further, or to be able to handle arbitrarily large transactions.

***

Thank you, loving this project, and planning to use it for Lightning Piggy's NWC functionality!