### PR TITLE
get_info: add support for NIP47 notifications

### DIFF
--- a/src/Nip47.cpp
+++ b/src/Nip47.cpp
@@ -454,6 +454,10 @@ void Nip47::parseResponse(SignedNostrEvent *response, Nip47Response<GetInfoRespo
                     for (JsonVariant v : methodsObj) {
                         out.result.methods.push_back(v.as<NostrString>());
                     }
+                    JsonArray notificationsObj = data["notifications"].as<JsonArray>();
+                    for (JsonVariant v : notificationsObj) {
+                        out.result.notifications.push_back(v.as<NostrString>());
+                    }
                     return;
                 }
             }

--- a/src/Nip47.h
+++ b/src/Nip47.h
@@ -120,6 +120,7 @@ typedef struct s_GetInfoResponse {
     unsigned long long blockHeight;
     NostrString blockHash;
     std::vector<NostrString> methods;
+    std::vector<NostrString> notifications;
 } GetInfoResponse;
 
 typedef struct s_NWCData {


### PR DESCRIPTION
It's pretty self explanatory :-)

Notifications are optional, according to the spec, and Alby doesn't seem to offer them, nor does coinos... but I hope they add it soon, or to find a NWC provider that offers it...