### PR TITLE
Make uBitcoin a dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/uBitcoin"]
-	path = src/uBitcoin
-	url = git@github.com:micro-bitcoin/uBitcoin.git

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Check the [platformio registry page](https://registry.platformio.org/libraries/r
 
 ### ESP32 dependencies
 This library depends on the following additional libraries for the esp32 platform:
-- WebSockets@^2.4.1
+- ArduinoJson (>=7.1.0)
+- uBitcoin (>=0.2.0)
+- WebSockets (>=2.4.1)
 
 
 ## Usage

--- a/library.json
+++ b/library.json
@@ -29,6 +29,7 @@
     "version": "1.3.4",
     "dependencies": {
         "ArduinoJson": "^7.1.0",
+        "uBitcoin": "^0.2.0",
         "WebSockets": "^2.4.1"
     }
 }

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This library allows you to send and receive Nostr events.
 category=Communication
 url=https://github.com/riccardobl/nostrduino
 architectures=esp32
-depends=ArduinoJson (>=7.1.0),WebSockets (>=2.4.1)
+depends=ArduinoJson (>=7.1.0),uBitcoin (>=0.2.0),WebSockets (>=2.4.1)

--- a/src/NostrUtils.cpp
+++ b/src/NostrUtils.cpp
@@ -1,7 +1,7 @@
 #include "NostrUtils.h"
 
-#include "uBitcoin/src/Bitcoin.h"
-#include "uBitcoin/src/Hash.h"
+#include "Hash.h" // depends on uBitcoin: https://github.com/micro-bitcoin/uBitcoin
+#include "Bitcoin.h" // depends on uBitcoin: https://github.com/micro-bitcoin/uBitcoin
 
 using namespace nostr;
 


### PR DESCRIPTION
This works fine for me, using the Arduino IDE (1.8.13) on Linux.

I don't see any conflict, but I did notice that esp-idf 5.3.2 has these 2 files called hash.h:

./esp-idf_5.3.2/components/mbedtls/mbedtls/tests/include/test/drivers/hash.h                                                                                                                                                                                                             
./esp-idf_5.3.2/components/openthread/openthread/third_party/mbedtls/repo/tests/include/test/drivers/hash.h

They're lowercase hash.h, so (at least on Linux and MacOS) that's different from the Hash.h in uBitcoin.

I doubt these would conflict, even on Windows, but if you have any issues, please me know and then we can look for another solution :-)

Thank you!