### PR TITLE
NWC: add support for payment notifications

### DIFF
--- a/src/Nip47.cpp
+++ b/src/Nip47.cpp
@@ -501,12 +501,6 @@ void Nip47::parseResponse(SignedNostrEvent *response, Nip47Response<Notification
     out.resultType = ""; // Initialize resultType
     Utils::log("NWC: received notification response");
 
-    if (response->getKind() != 23196) {
-        out.errorCode = "INVALID_KIND";
-        out.errorMessage = "Unexpected event kind: " + NostrString_intToString(response->getKind());
-        return;
-    }
-
     if (!response->verify()) {
         out.errorCode = "VERIFICATION_FAILED";
         out.errorMessage = "Notification event verification failed";

--- a/src/Nip47.cpp
+++ b/src/Nip47.cpp
@@ -522,7 +522,7 @@ void Nip47::parseResponse(SignedNostrEvent *response, Nip47Response<Notification
         return;
     }
 
-    StaticJsonDocument<1024> doc;
+    JsonDocument doc;
     DeserializationError error = deserializeJson(doc, content);
     if (error) {
         out.errorCode = "JSON_PARSE_ERROR";

--- a/src/Nip47.cpp
+++ b/src/Nip47.cpp
@@ -498,65 +498,43 @@ void Nip47::parseNWC(NostrString nwc, NWCData &data) {
 void Nip47::parseResponse(SignedNostrEvent *response, Nip47Response<NotificationResponse> &out) {
     out.errorCode = "";
     out.errorMessage = "";
-    out.resultType = ""; // Initialize resultType
+    out.resultType = "";
     Utils::log("NWC: received notification response");
 
-    if (!response->verify()) {
-        out.errorCode = "VERIFICATION_FAILED";
-        out.errorMessage = "Notification event verification failed";
-        return;
+    if (response->verify()) {
+        NostrString content = this->nip04.decrypt(this->userPrivKey, this->servicePubKey, response->getContent());
+        JsonDocument doc;
+        Utils::jsonParse(&content, &doc);
+
+        JsonObject error = doc["error"];
+        if (!error.isNull()) {
+            out.errorCode = error["code"].as<NostrString>();
+            out.errorMessage = error["message"].as<NostrString>();
+        } else {
+            NostrString notificationType = doc["notification_type"].as<NostrString>();
+            JsonObject notification = doc["notification"].as<JsonObject>();
+            if (NostrString_length(notificationType) > 0 && notification) {
+                Nip47Notification nip47Notification = {};
+                nip47Notification.notificationType = notificationType;
+                nip47Notification.type = notification["type"].as<NostrString>();
+                nip47Notification.invoice = notification["invoice"].as<NostrString>();
+                nip47Notification.description = notification["description"].as<NostrString>();
+                nip47Notification.descriptionHash = notification["description_hash"].as<NostrString>();
+                nip47Notification.preimage = notification["preimage"].as<NostrString>();
+                nip47Notification.paymentHash = notification["payment_hash"].as<NostrString>();
+                nip47Notification.amount = notification["amount"].as<uint64_t>();
+                nip47Notification.feesPaid = notification["fees_paid"].as<uint64_t>();
+                nip47Notification.createdAt = notification["created_at"].as<uint64_t>();
+                nip47Notification.settledAt = notification["settled_at"].as<uint64_t>();
+
+                out.resultType = notificationType;
+                out.result.notification = nip47Notification;
+                return;
+            }
+        }
     }
-
-    NostrString content;
-    try {
-        content = this->nip04.decrypt(this->userPrivKey, this->servicePubKey, response->getContent());
-    } catch (const std::exception& e) {
-        out.errorCode = "DECRYPTION_FAILED";
-        out.errorMessage = "Failed to decrypt notification content: " + NostrString(e.what());
-        return;
+    if (NostrString_length(out.errorCode) == 0) {
+        out.errorCode = "OTHER";
+        out.errorMessage = "Invalid Notification Event";
     }
-
-    if (NostrString_length(content) == 0) {
-        out.errorCode = "EMPTY_CONTENT";
-        out.errorMessage = "Decrypted notification content is empty";
-        return;
-    }
-
-    JsonDocument doc;
-    DeserializationError error = deserializeJson(doc, content);
-    if (error) {
-        out.errorCode = "JSON_PARSE_ERROR";
-        out.errorMessage = "Failed to parse notification JSON: " + NostrString(error.c_str());
-        return;
-    }
-
-    NostrString notificationType = doc["notification_type"] | "";
-    if (NostrString_length(notificationType) == 0) {
-        out.errorCode = "MISSING_TYPE";
-        out.errorMessage = "Notification missing 'notification_type' field";
-        return;
-    }
-
-    JsonObject notification = doc["notification"];
-    if (!notification) {
-        out.errorCode = "MISSING_NOTIFICATION";
-        out.errorMessage = "Notification missing 'notification' object";
-        return;
-    }
-
-    Nip47Notification nip47Notification = {};
-    nip47Notification.notificationType = notificationType;
-    nip47Notification.type = notification["type"] | "";
-    nip47Notification.invoice = notification["invoice"] | "";
-    nip47Notification.description = notification["description"] | "";
-    nip47Notification.descriptionHash = notification["description_hash"] | "";
-    nip47Notification.preimage = notification["preimage"] | "";
-    nip47Notification.paymentHash = notification["payment_hash"] | "";
-    nip47Notification.amount = notification["amount"] | 0ULL;
-    nip47Notification.feesPaid = notification["fees_paid"] | 0ULL;
-    nip47Notification.createdAt = notification["created_at"] | 0ULL;
-    nip47Notification.settledAt = notification["settled_at"] | 0ULL;
-
-    out.resultType = notificationType; // Set resultType to match notification_type
-    out.result.notification = nip47Notification;
 }

--- a/src/Nip47.h
+++ b/src/Nip47.h
@@ -129,6 +129,26 @@ typedef struct s_NWCData {
     NostrString secret;
 } NWCData;
 
+
+typedef struct s_Nip47Notification {
+    NostrString notificationType;
+    NostrString type;
+    NostrString invoice;
+    NostrString description;
+    NostrString descriptionHash;
+    NostrString preimage;
+    NostrString paymentHash;
+    unsigned long long amount;
+    unsigned long long feesPaid;
+    unsigned long long createdAt;
+    unsigned long long settledAt;
+} Nip47Notification;
+
+typedef struct s_NotificationResponse {
+    Nip47Notification notification;
+} NotificationResponse;
+
+
 class Nip47 {
   public:
     Nip47(){};
@@ -153,6 +173,7 @@ class Nip47 {
     void parseResponse(SignedNostrEvent *response, Nip47Response<ListTransactionsResponse> &out);
     void parseResponse(SignedNostrEvent *response, Nip47Response<GetBalanceResponse> &out);
     void parseResponse(SignedNostrEvent *response, Nip47Response<GetInfoResponse> &out);
+    void parseResponse(SignedNostrEvent *response, Nip47Response<NotificationResponse> &out);
     static void parseNWC(NostrString, NWCData &);
 
   private:
@@ -160,6 +181,7 @@ class Nip47 {
     NostrString userPrivKey;
     Nip04 nip04;
     SignedNostrEvent createEvent(NostrString method, JsonDocument doc);
+    std::function<void(Nip47Notification)> notificationCallback;
 };
 } 
 

--- a/src/services/NWC.cpp
+++ b/src/services/NWC.cpp
@@ -31,14 +31,12 @@ void NWC::close() {
 void NWC::loop() {
     this->pool->loop();
     for (auto it = this->callbacks.begin(); it != this->callbacks.end();) {
-
         if (it->get()->n == 0) {
             NostrString subId = it->get()->subId;
             this->pool->closeSubscription(subId);
             it = this->callbacks.erase(it);
             continue;
         }
-
         if (Utils::unixTimeSeconds() - it->get()->timestampSeconds > it->get()->timeoutSeconds) {
             NostrString subId = it->get()->subId;
             this->pool->closeSubscription(subId);

--- a/src/services/NWC.cpp
+++ b/src/services/NWC.cpp
@@ -67,9 +67,9 @@ NostrString NWC::sendEvent(SignedNostrEvent *event = nullptr) {
             NostrString ref = event ? receivedEvent->getTags()->getTag("e")[0] : receivedEvent->getSubId();
             for (auto it = this->callbacks.begin(); it != this->callbacks.end(); it++) {
                 if (NostrString_equals(event ? it->get()->eventId : it->get()->subId, ref)) {
-                    if (!event || it->get()->n > 0) { // Check n only for event case, because 
+                    if (!event || it->get()->n > 0) { // If no event is provided, always call. Otherwise, only do so if n > 0.
                         it->get()->call(&this->nip47, receivedEvent);
-                        if (event) it->get()->n--;
+                        if (event) it->get()->n--;  // Decrement only if event provided and called
                     }
                     break;
                 }
@@ -99,7 +99,6 @@ void NWC::subscribeNotifications(std::function<void(NotificationResponse)> onRes
     callback->timestampSeconds = Utils::unixTimeSeconds();
     callback->timeoutSeconds = NWC_INFINITE_TIMEOUT;
     callback->subId = sendEvent();
-    callback->n = 1;
     this->callbacks.push_back(std::move(callback));
 }
 

--- a/src/services/NWC.cpp
+++ b/src/services/NWC.cpp
@@ -74,6 +74,51 @@ NostrString NWC::sendEvent(SignedNostrEvent *event) {
     return subId;
 }
 
+// This function has similaries with sendEvent() but it's quite different,
+// as subscribing to notifications doesn't involve sending any event.
+void NWC::subscribeNotifications(std::function<void(NotificationResponse)> onRes, std::function<void(NostrString, NostrString)> onErr) {
+    if (!pool) {
+        Utils::log("Cannot subscribe to notifications: Pool is null");
+        if (onErr) onErr("NO_POOL", "Pool is null");
+        return;
+    }
+    if (pool->getRelays().empty()) {
+        Utils::log("Cannot subscribe to notifications: No relays connected");
+        if (onErr) onErr("NO_RELAYS", "No relays connected");
+        return;
+    }
+
+    NostrString notificationSubId = pool->subscribeMany(
+        {this->nwc.relay}, {{{"kinds", {"23196"}}, {"#p", {this->accountPubKey}}}},
+        [this, onRes, onErr](const NostrString &subId, SignedNostrEvent *event) {
+            Nip47Response<NotificationResponse> resp;
+            nip47.parseResponse(event, resp);
+            if (NostrString_length(resp.errorCode) > 0) {
+                if (onErr) onErr(resp.errorCode, resp.errorMessage);
+            } else {
+                if (onRes) onRes(resp.result);
+            }
+            // No delete event here; pool manages it
+        },
+        [onErr](const NostrString &subId, const NostrString &reason) {
+            Utils::log("Notification subscription closed: " + reason);
+            if (onErr) onErr("SUB_CLOSED", reason);
+        },
+        [](const NostrString &subId) { Utils::log("Notification subscription EOS"); }
+    );
+
+    std::unique_ptr<NWCResponseCallback<NotificationResponse>> callback(new NWCResponseCallback<NotificationResponse>());
+    callback->onRes = onRes;
+    callback->onErr = onErr;
+    callback->timestampSeconds = Utils::unixTimeSeconds();
+    callback->timeoutSeconds = NWC_INFINITE_TIMEOUT;
+    callback->eventId = ""; // notifications are not tied to events
+    callback->subId = notificationSubId;
+    callback->n = 1;
+    this->callbacks.push_back(std::move(callback));
+    Utils::log("Subscribed to notifications with sub ID: " + notificationSubId);
+}
+
 void NWC::payInvoice(NostrString invoice, unsigned long amount, std::function<void(PayInvoiceResponse)> onRes, std::function<void(NostrString, NostrString)> onErr) {
     SignedNostrEvent ev = this->nip47.payInvoice(invoice, amount);
     std::unique_ptr<NWCResponseCallback<PayInvoiceResponse>> callback(new NWCResponseCallback<PayInvoiceResponse>());
@@ -197,45 +242,4 @@ void NWC::getInfo(std::function<void(GetInfoResponse)> onRes, std::function<void
     this->callbacks.push_back(std::move(callback));
 }
 
-void NWC::subscribeNotifications(std::function<void(NotificationResponse)> onRes, std::function<void(NostrString, NostrString)> onErr) {
-    if (!pool) {
-        Utils::log("Cannot subscribe to notifications: Pool is null");
-        if (onErr) onErr("NO_POOL", "Pool is null");
-        return;
-    }
-    if (pool->getRelays().empty()) {
-        Utils::log("Cannot subscribe to notifications: No relays connected");
-        if (onErr) onErr("NO_RELAYS", "No relays connected");
-        return;
-    }
 
-    NostrString notificationSubId = pool->subscribeMany(
-        {this->nwc.relay}, {{{"kinds", {"23196"}}, {"#p", {this->accountPubKey}}}},
-        [this, onRes, onErr](const NostrString &subId, SignedNostrEvent *event) {
-            Nip47Response<NotificationResponse> resp;
-            nip47.parseResponse(event, resp);
-            if (NostrString_length(resp.errorCode) > 0) {
-                if (onErr) onErr(resp.errorCode, resp.errorMessage);
-            } else {
-                if (onRes) onRes(resp.result);
-            }
-            // No delete event here; pool manages it
-        },
-        [onErr](const NostrString &subId, const NostrString &reason) {
-            Utils::log("Notification subscription closed: " + reason);
-            if (onErr) onErr("SUB_CLOSED", reason);
-        },
-        [](const NostrString &subId) { Utils::log("Notification subscription EOS"); }
-    );
-
-    std::unique_ptr<NWCResponseCallback<NotificationResponse>> callback(new NWCResponseCallback<NotificationResponse>());
-    callback->onRes = onRes;
-    callback->onErr = onErr;
-    callback->timestampSeconds = Utils::unixTimeSeconds();
-    callback->timeoutSeconds = NWC_INFINITE_TIMEOUT;
-    callback->eventId = ""; // notifications are not tied to events
-    callback->subId = notificationSubId;
-    callback->n = 1;
-    this->callbacks.push_back(std::move(callback));
-    Utils::log("Subscribed to notifications with sub ID: " + notificationSubId);
-}

--- a/src/services/NWC.cpp
+++ b/src/services/NWC.cpp
@@ -52,7 +52,7 @@ NostrString NWC::sendEvent(SignedNostrEvent *eventToSend = nullptr) {
     // Create JSON filter dynamically
     JsonDocument doc;
     JsonArray filters = doc.to<JsonArray>();
-    JsonObject filter = filters.createNestedObject();
+    JsonObject filter = filters.add<JsonObject>();
     filter["kinds"].add(kind);
     filter["#p"].add(this->accountPubKey);
     if (eventToSend) filter["#e"].add(eventToSend->getId());

--- a/src/services/NWC.cpp
+++ b/src/services/NWC.cpp
@@ -74,10 +74,10 @@ NostrString NWC::sendEvent(SignedNostrEvent *event) {
     return subId;
 }
 
-NostrString NWC::subscribeInternal(std::function<void(NotificationResponse)> onRes, std::function<void(NostrString, NostrString)> onErr) {
+NostrString NWC::subscribeInternal() {
     return pool->subscribeMany(
         {this->nwc.relay}, {{{"kinds", {"23196"}}, {"#p", {this->accountPubKey}}}},
-        [this, onRes, onErr](const NostrString &subId, SignedNostrEvent *event) {
+        [&](const NostrString &subId, SignedNostrEvent *event) {
             NostrString subRef = event->getSubId();
             for (auto it = this->callbacks.begin(); it != this->callbacks.end(); it++) {
                 if (NostrString_equals(it->get()->subId, subRef)) {
@@ -95,8 +95,7 @@ void NWC::subscribeNotifications(std::function<void(NotificationResponse)> onRes
     callback->onErr = onErr;
     callback->timestampSeconds = Utils::unixTimeSeconds();
     callback->timeoutSeconds = NWC_INFINITE_TIMEOUT;
-    callback->eventId = ""; // notifications are not tied to events
-    callback->subId = subscribeInternal(onRes, onErr);
+    callback->subId = subscribeInternal();
     callback->n = 1;
     this->callbacks.push_back(std::move(callback));
 }

--- a/src/services/NWC.cpp
+++ b/src/services/NWC.cpp
@@ -69,7 +69,7 @@ NostrString NWC::sendEvent(SignedNostrEvent *eventToSend = nullptr) {
                 if (NostrString_equals(eventToSend ? it->get()->eventId : it->get()->subId, ref)) {
                     if (!eventToSend || it->get()->n > 0) { // If no eventToSend is provided, always call. Otherwise, only do so if n > 0.
                         it->get()->call(&this->nip47, event);
-                    }
+                    } 
                     it->get()->n--;
                     break;
                 }

--- a/src/services/NWC.cpp
+++ b/src/services/NWC.cpp
@@ -241,5 +241,3 @@ void NWC::getInfo(std::function<void(GetInfoResponse)> onRes, std::function<void
     callback->subId = this->sendEvent(&ev);
     this->callbacks.push_back(std::move(callback));
 }
-
-

--- a/src/services/NWC.cpp
+++ b/src/services/NWC.cpp
@@ -48,7 +48,6 @@ void NWC::loop() {
     }
 }
 
-
 NostrString NWC::sendEvent(SignedNostrEvent *event) {
     NostrString subId = this->pool->subscribeMany(
         {this->nwc.relay}, {{{"kinds", {"23195"}}, {"#p", {this->accountPubKey}}, {"#e", {event->getId()}}}},

--- a/src/services/NWC.cpp
+++ b/src/services/NWC.cpp
@@ -94,7 +94,7 @@ void NWC::subscribeNotifications(std::function<void(NotificationResponse)> onRes
     callback->timestampSeconds = Utils::unixTimeSeconds();
     callback->timeoutSeconds = NWC_INFINITE_TIMEOUT;
     callback->subId = sendEvent();
-    callback->n = -1; // never timeout
+    callback->n = -1; // don't disconnect after n responses are received; stay connected, waiting for notifications
     this->callbacks.push_back(std::move(callback));
 }
 

--- a/src/services/NWC.cpp
+++ b/src/services/NWC.cpp
@@ -50,7 +50,7 @@ void NWC::loop() {
 NostrString NWC::sendEvent(SignedNostrEvent *eventToSend = nullptr) {
     int kind = eventToSend ? NWC_RESPONSE_KIND : NWC_NOTIFICATION_KIND; // If an event is sent, expect a reponse. Otherwise, expect a notification.
     // Create JSON filter dynamically
-    DynamicJsonDocument doc(160); // enough for kind, #p and #e
+    JsonDocument doc;
     JsonArray filters = doc.to<JsonArray>();
     JsonObject filter = filters.createNestedObject();
     filter["kinds"].add(kind);
@@ -60,8 +60,7 @@ NostrString NWC::sendEvent(SignedNostrEvent *eventToSend = nullptr) {
     // Common subscription logic
     NostrString subId = this->pool->subscribeMany(
         {this->nwc.relay}, filters,
-        [&](const NostrString &subId, SignedNostrEvent *event) {
-            if (event->getTags()->getTag("e").empty()) eventToSend = nullptr; // workaround eventToSend not being null
+        [this, eventToSend](const NostrString &subId, SignedNostrEvent *event) {
             NostrString ref = eventToSend ? event->getTags()->getTag("e")[0] : event->getSubId();
             for (auto it = this->callbacks.begin(); it != this->callbacks.end(); it++) {
                 if (NostrString_equals(eventToSend ? it->get()->eventId : it->get()->subId, ref)) {

--- a/src/services/NWC.cpp
+++ b/src/services/NWC.cpp
@@ -75,9 +75,7 @@ NostrString NWC::sendEvent(SignedNostrEvent *event = nullptr) {
                 }
             }
         },
-        [&](const String &subId, const String &reason) { Utils::log("NWC: closed subscription: " + reason); },
-        [&](const String &subId) { Utils::log("NWC: EOS"); }
-    );
+        [&](const String &subId, const String &reason) { Utils::log("NWC: closed subscription: " + reason); }, [&](const String &subId) { Utils::log("NWC: EOS"); });
 
     // Publish if event is provided
     if (event) {

--- a/src/services/NWC.cpp
+++ b/src/services/NWC.cpp
@@ -48,12 +48,11 @@ void NWC::loop() {
 
 // Subscribe to NWC reponses or notifications, and send an event, if provided.
 NostrString NWC::sendEvent(SignedNostrEvent *eventToSend = nullptr) {
-    int kind = eventToSend ? NWC_RESPONSE_KIND : NWC_NOTIFICATION_KIND; // If an event is sent, expect a reponse. Otherwise, expect a notification.
-    // Create JSON filter dynamically
+    // These filters have to be created dynamically because the #e tag is conditional
     JsonDocument doc;
     JsonArray filters = doc.to<JsonArray>();
     JsonObject filter = filters.add<JsonObject>();
-    filter["kinds"].add(kind);
+    filter["kinds"].add(eventToSend ? NWC_RESPONSE_KIND : NWC_NOTIFICATION_KIND); // If an event is sent, expect a reponse. Otherwise, expect a notification.
     filter["#p"].add(this->accountPubKey);
     if (eventToSend) filter["#e"].add(eventToSend->getId());
 
@@ -74,7 +73,7 @@ NostrString NWC::sendEvent(SignedNostrEvent *eventToSend = nullptr) {
         },
         [&](const String &subId, const String &reason) { Utils::log("NWC: closed subscription: " + reason); }, [&](const String &subId) { Utils::log("NWC: EOS"); });
 
-    // Publish if event is provided
+    // Publish event, if provided
     if (eventToSend) {
         this->pool->publish(
             {this->nwc.relay}, eventToSend,

--- a/src/services/NWC.cpp
+++ b/src/services/NWC.cpp
@@ -69,8 +69,8 @@ NostrString NWC::sendEvent(SignedNostrEvent *event = nullptr) {
                 if (NostrString_equals(event ? it->get()->eventId : it->get()->subId, ref)) {
                     if (!event || it->get()->n > 0) { // If no event is provided, always call. Otherwise, only do so if n > 0.
                         it->get()->call(&this->nip47, receivedEvent);
-                        if (event) it->get()->n--;  // Decrement only if event provided and called
                     }
+                    it->get()->n--;
                     break;
                 }
             }

--- a/src/services/NWC.cpp
+++ b/src/services/NWC.cpp
@@ -77,7 +77,7 @@ void NWC::subscribeNotifications(std::function<void(NotificationResponse)> onRes
     callback->onRes = onRes;
     callback->onErr = onErr;
     callback->timestampSeconds = Utils::unixTimeSeconds();
-    callback->timeoutSeconds = NWC_INFINITE_TIMEOUT;
+    callback->timeoutSeconds = NWC_INFINITE_TIMEOUT; // notification subscriptions don't timeout, they can come after any amount of time
     callback->subId = pool->subscribeMany(
         {this->nwc.relay}, {{{"kinds", {NWC_NOTIFICATION_KIND}}, {"#p", {this->accountPubKey}}}},
         [&](const NostrString &subId, SignedNostrEvent *event) {

--- a/src/services/NWC.h
+++ b/src/services/NWC.h
@@ -11,8 +11,8 @@
 #include "NostrTransport.h"
 #include "NostrUtils.h"
 
-#define NWC_RESPONSE_KIND 23195
-#define NWC_NOTIFICATION_KIND 23196
+#define NWC_RESPONSE_KIND "23195"
+#define NWC_NOTIFICATION_KIND "23196"
 
 #define NWC_DEFAULT_TIMEOUT (60 * 10) // 10 minutes in seconds
 #define NWC_INFINITE_TIMEOUT (0xFFFFFFFF) // Max unsigned int, ~136 years

--- a/src/services/NWC.h
+++ b/src/services/NWC.h
@@ -12,6 +12,7 @@
 #include "NostrUtils.h"
 
 #define NWC_DEFAULT_TIMEOUT (60 * 10) // 10 minutes in seconds
+#define NWC_INFINITE_TIMEOUT (0xFFFFFFFF) // Max unsigned int, ~136 years
 
 namespace nostr {
 class NWCResponseCallbackBase {
@@ -171,7 +172,6 @@ class NWC {
   private:
     Transport *transport;
     NostrString sendEvent(SignedNostrEvent *ev);
-    NostrString subscribeInternal();
     std::unique_ptr<NostrPool> pool;
     NWCData nwc;
     Nip47 nip47;

--- a/src/services/NWC.h
+++ b/src/services/NWC.h
@@ -11,6 +11,8 @@
 #include "NostrTransport.h"
 #include "NostrUtils.h"
 
+#define NWC_DEFAULT_TIMEOUT (60 * 10) // 10 minutes in seconds
+
 namespace nostr {
 class NWCResponseCallbackBase {
   public:
@@ -18,6 +20,7 @@ class NWCResponseCallbackBase {
     virtual void call(Nip47 *nip47, SignedNostrEvent *ev) {}
     std::function<void(NostrString, NostrString)> onErr = nullptr;
     unsigned long long timestampSeconds;
+    unsigned int timeoutSeconds = NWC_DEFAULT_TIMEOUT;
     NostrString eventId;
     NostrString subId;
     unsigned int n = 1;
@@ -157,6 +160,13 @@ class NWC {
      * @param onErr A callback that will be called when the info retrieval fails (optional)
      */
     void getInfo(std::function<void(GetInfoResponse)> onRes = nullptr, std::function<void(NostrString, NostrString)> onErr = nullptr);
+
+    /**
+     * Subscribe to payment notifications
+     * @param onRes A callback that will be called when a payment notification is received
+     * @param onErr A callback that will be called when an error is received (optional)
+     */
+    void subscribeNotifications(std::function<void(NotificationResponse)> onRes, std::function<void(NostrString, NostrString)> onErr);
 
   private:
     Transport *transport;

--- a/src/services/NWC.h
+++ b/src/services/NWC.h
@@ -171,7 +171,7 @@ class NWC {
   private:
     Transport *transport;
     NostrString sendEvent(SignedNostrEvent *ev);
-    NostrString subscribeInternal(std::function<void(NotificationResponse)> onRes, std::function<void(NostrString, NostrString)> onErr);
+    NostrString subscribeInternal();
     std::unique_ptr<NostrPool> pool;
     NWCData nwc;
     Nip47 nip47;

--- a/src/services/NWC.h
+++ b/src/services/NWC.h
@@ -11,6 +11,9 @@
 #include "NostrTransport.h"
 #include "NostrUtils.h"
 
+#define NWC_RESPONSE_KIND 23195
+#define NWC_NOTIFICATION_KIND 23196
+
 #define NWC_DEFAULT_TIMEOUT (60 * 10) // 10 minutes in seconds
 #define NWC_INFINITE_TIMEOUT (0xFFFFFFFF) // Max unsigned int, ~136 years
 

--- a/src/services/NWC.h
+++ b/src/services/NWC.h
@@ -171,6 +171,7 @@ class NWC {
   private:
     Transport *transport;
     NostrString sendEvent(SignedNostrEvent *ev);
+    NostrString subscribeInternal(std::function<void(NotificationResponse)> onRes, std::function<void(NostrString, NostrString)> onErr);
     std::unique_ptr<NostrPool> pool;
     NWCData nwc;
     Nip47 nip47;


### PR DESCRIPTION
This is a first pull request for payment notifications.

Here's an example of the usage:

```
nwc->subscribeNotifications(
        [](nostr::NotificationResponse res) {
            nostr::Nip47Notification notification = res.notification;
            Serial.println("Notification Type: " + notification.notificationType);
            Serial.println("Type: " + notification.type);
            Serial.println("Amount: " + NostrString_fromUInt(notification.amount));
            Serial.println("Payment Hash: " + notification.paymentHash);
            Serial.println("Description: " + notification.description);
            Serial.println("Description Hash: " + notification.descriptionHash);
            Serial.println("Invoice: " + notification.invoice);
            Serial.println("Preimage: " + notification.preimage);
            Serial.println("Fees Paid: " + NostrString_fromUInt(notification.feesPaid));
            Serial.println("Created At: " + NostrString_fromUInt(notification.createdAt));
            Serial.println("Settled At: " + NostrString_fromUInt(notification.settledAt));
        },
        [](NostrString errorCode, NostrString errorMessage) {
            Serial.println("Notification Error: " + errorCode + " - " + errorMessage);
        }
    );
```

It might be good to extend the examples to show a bit more, like listTransactions and subscribeNotifications, in a separate pull request, or in the same one.